### PR TITLE
Light: Set MAX_LCD_BRIGHTNESS to 4095

### DIFF
--- a/light/Light.cpp
+++ b/light/Light.cpp
@@ -36,7 +36,7 @@
 #define START_IDX       "start_idx"
 
 #define MAX_LED_BRIGHTNESS    255
-#define MAX_LCD_BRIGHTNESS    255
+#define MAX_LCD_BRIGHTNESS    4095
 
 /*
  * 8 duty percent steps.


### PR DESCRIPTION
* All Custom ROM's I'm aware of have 4095 value, this is to prevent compablity issues with custom kernels.